### PR TITLE
✨ feat(annuaire): pagination et disposition en deux colonnes

### DIFF
--- a/pages/annuaire-sites-publics-senegal/index.vue
+++ b/pages/annuaire-sites-publics-senegal/index.vue
@@ -69,7 +69,7 @@ const types = computed(() => {
 /* Pagination */
 
 const page = ref(1)
-const pageCount = 10
+const pageCount = 20
 
 const rowsFilteredSites = computed(() => {
     return filteredSites.value.slice((page.value - 1) * pageCount, (page.value) * pageCount)
@@ -100,7 +100,7 @@ watch(selectedType, () => {
             <USelect class="w-full sm:w-full mb-3 custom-shadow" size="lg" icon="i-heroicons-funnel"
                 placeholder="Filtrer par type" v-model="selectedType" :options="types" />
 
-            <div class="space-y-2">
+            <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <UCard v-for="site in rowsFilteredSites" :key="site.url" class="cursor-pointer custom-shadow">
                     <ULink :to="site.url" target="_blank"
                         class="text-blue-600 hover:text-blue-800 underline text-sm font-semibold">


### PR DESCRIPTION
## Description
Les modifications principales comprennent l'utilisation d'une grille à deux colonnes pour les cartes de sites Web et l'augmentation du nombre de résultats par page à 20

### Amélioration de l'annuaire des sites web publics du Sénégal

Cette PR améliore l'annuaire des sites web publics du Sénégal en introduisant les fonctionnalités suivantes :

- Mise en place de la pagination pour afficher 20 résultats par page.
- Affichage des résultats en deux colonnes pour pour améliorer l'affichage des cartes de sites web.

## Type de modification

- [x] Amélioration de l'affichage


### Étapes de test :

1. Exécuter `npm run dev` pour démarrer l'application.
2. Naviguer vers `http://localhost:3000` pour accéder à l'annuaire des sites web publics.
3. Vérifier que les résultats sont paginés par tranche de 20 et que la navigation entre les pages fonctionne correctement.
4. Vérifier que les cartes des sites web sont affichées en deux colonnes.

## Captures d'écran (le cas échéant)

<img width="1498" alt="Screenshot 2024-07-09 at 14 05 47" src="https://github.com/Code-for-Senegal/vie-publique.sn/assets/47165947/dbde67a2-93d1-47ae-a160-a7d7e3a70312">


## Problèmes connus

Aucun problème connu.


## Remarques supplémentaires

Aucune remarque supplémentaire.
