### PR TITLE
fix: Améliorer l'affichage des erreurs pour une meilleure expérience utilisateur

### DIFF
--- a/app/components/Election/ElectionPvImage.vue
+++ b/app/components/Election/ElectionPvImage.vue
@@ -18,9 +18,13 @@
     ></div>
 
     <!-- Error State -->
-    <div v-if="error" class="rounded bg-red-50 p-4 text-center text-red-500">
-      Impossible de charger l'image
-    </div>
+    <UAlert
+      v-if="error"
+      title="Erreur de chargement"
+      description="Impossible de charger l'image"
+      color="red"
+      icon="i-heroicons-exclamation-triangle"
+    />
   </div>
 </template>
 

--- a/app/components/HomeAssemblyQuestions.vue
+++ b/app/components/HomeAssemblyQuestions.vue
@@ -15,12 +15,13 @@
     </div>
 
     <!-- Error state -->
-    <div
+    <UAlert
       v-else-if="error"
-      class="p-4 text-center text-red-500 dark:text-red-300"
-    >
-      {{ error }}
-    </div>
+      title="Erreur de chargement"
+      description="Impossible de charger les questions écrites"
+      color="red"
+      icon="i-heroicons-exclamation-triangle"
+    />
 
     <!-- Content -->
     <div v-else>

--- a/app/composables/useBictorysDonation.ts
+++ b/app/composables/useBictorysDonation.ts
@@ -55,7 +55,21 @@ export const useBictorysDonation = () => {
         throw new Error('Impossible d\'initialiser le paiement')
       }
     } catch (err: any) {
-      error.value = err.message || 'Une erreur est survenue'
+      // Gestion des erreurs de manière user-friendly
+      if (err.statusCode === 404) {
+        error.value = 'Le service de paiement est temporairement indisponible. Veuillez réessayer plus tard.'
+      } else if (err.statusCode === 500 || err.statusCode >= 500) {
+        error.value = 'Une erreur serveur est survenue. Veuillez réessayer dans quelques instants.'
+      } else if (err.statusCode === 400) {
+        error.value = 'Les informations fournies sont invalides. Veuillez vérifier vos données.'
+      } else if (err.message?.includes('Network') || err.message?.includes('fetch')) {
+        error.value = 'Impossible de contacter le serveur. Vérifiez votre connexion internet.'
+      } else if (err.message && !err.message.includes('POST') && !err.message.includes('GET') && !err.message.includes('api/')) {
+        // Utiliser le message d'erreur s'il est user-friendly (ne contient pas de détails techniques)
+        error.value = err.message
+      } else {
+        error.value = 'Une erreur est survenue lors de l\'initialisation du paiement. Veuillez réessayer.'
+      }
 
       return {
         success: false,

--- a/app/composables/usePaydunyaDonation.ts
+++ b/app/composables/usePaydunyaDonation.ts
@@ -56,7 +56,21 @@ export const usePaydunyaDonation = () => {
         throw new Error('Impossible d\'initialiser le paiement')
       }
     } catch (err: any) {
-      error.value = err.message || 'Une erreur est survenue'
+      // Gestion des erreurs de manière user-friendly
+      if (err.statusCode === 404) {
+        error.value = 'Le service de paiement est temporairement indisponible. Veuillez réessayer plus tard.'
+      } else if (err.statusCode === 500 || err.statusCode >= 500) {
+        error.value = 'Une erreur serveur est survenue. Veuillez réessayer dans quelques instants.'
+      } else if (err.statusCode === 400) {
+        error.value = 'Les informations fournies sont invalides. Veuillez vérifier vos données.'
+      } else if (err.message?.includes('Network') || err.message?.includes('fetch')) {
+        error.value = 'Impossible de contacter le serveur. Vérifiez votre connexion internet.'
+      } else if (err.message && !err.message.includes('POST') && !err.message.includes('GET') && !err.message.includes('api/')) {
+        // Utiliser le message d'erreur s'il est user-friendly (ne contient pas de détails techniques)
+        error.value = err.message
+      } else {
+        error.value = 'Une erreur est survenue lors de l\'initialisation du paiement. Veuillez réessayer.'
+      }
 
       return {
         success: false,

--- a/app/pages/assemblee-nationale/actualites/[id]/[slug].vue
+++ b/app/pages/assemblee-nationale/actualites/[id]/[slug].vue
@@ -232,12 +232,13 @@ watchEffect(() => {
     </div>
 
     <!-- Error state -->
-    <div
-      v-else-if="error"
-      class="rounded-lg bg-red-50 p-4 text-center text-red-500"
-    >
-      {{ error }}
-    </div>
+    <UAlert v-else-if="error"
+        title="Erreur de chargement"
+        description="Une erreur est survenue lors du chargement de l'article"
+        color="red"
+        icon="i-heroicons-exclamation-triangle"
+        class="dark:text-white"
+    />
 
     <!-- Content -->
     <article

--- a/app/pages/assemblee-nationale/actualites/index.vue
+++ b/app/pages/assemblee-nationale/actualites/index.vue
@@ -204,12 +204,13 @@ const formatDateISO = (date: string) => {
       </div>
 
       <!-- Error state -->
-      <div
+      <UAlert
         v-else-if="error"
-        class="rounded-lg bg-red-50 p-4 text-center text-red-500 dark:bg-red-900/50 dark:text-red-400"
-      >
-        {{ error }}
-      </div>
+        title="Erreur de chargement"
+        description="Impossible de charger les actualités"
+        color="red"
+        icon="i-heroicons-exclamation-triangle"
+      />
 
       <!-- Content -->
       <div

--- a/app/pages/assemblee-nationale/bureau.vue
+++ b/app/pages/assemblee-nationale/bureau.vue
@@ -94,9 +94,13 @@ const groupedMembers = computed<OfficeGroup[]>(() => {
       </div>
 
       <!-- Error state -->
-      <div v-else-if="error" class="py-8 text-center text-red-500">
-        {{ error }}
-      </div>
+      <UAlert
+        v-else-if="error"
+        title="Erreur de chargement"
+        description="Impossible de charger les informations du bureau"
+        color="red"
+        icon="i-heroicons-exclamation-triangle"
+      />
 
       <!-- Content -->
       <div v-else class="space-y-8">

--- a/app/pages/assemblee-nationale/commissions/[id].vue
+++ b/app/pages/assemblee-nationale/commissions/[id].vue
@@ -295,9 +295,13 @@ const deputyUrl = computed((deputy: any) => {
       </div>
 
       <!-- Error state -->
-      <div v-else-if="error" class="py-8 text-center text-red-500">
-        {{ error }}
-      </div>
+      <UAlert
+        v-else-if="error"
+        title="Erreur de chargement"
+        description="Impossible de charger les informations de la commission"
+        color="red"
+        icon="i-heroicons-exclamation-triangle"
+      />
 
       <!-- Contenu de la commission -->
       <div v-else-if="commission" class="space-y-8 dark:text-black">

--- a/app/pages/assemblee-nationale/commissions/index.vue
+++ b/app/pages/assemblee-nationale/commissions/index.vue
@@ -210,9 +210,13 @@ const filteredCommissions = computed(() => {
       </div>
 
       <!-- Error state -->
-      <div v-else-if="error" class="py-8 text-center text-red-500">
-        {{ error }}
-      </div>
+      <UAlert
+        v-else-if="error"
+        title="Erreur de chargement"
+        description="Impossible de charger la liste des commissions"
+        color="red"
+        icon="i-heroicons-exclamation-triangle"
+      />
 
       <!-- Liste des commissions -->
       <div v-else class="grid gap-2">

--- a/app/pages/assemblee-nationale/deputes/[id]/[name].vue
+++ b/app/pages/assemblee-nationale/deputes/[id]/[name].vue
@@ -15,9 +15,13 @@
     </div>
 
     <!-- Error state -->
-    <div v-else-if="error" class="py-8 text-center text-red-500">
-      {{ error }}
-    </div>
+    <UAlert
+      v-else-if="error"
+      title="Erreur"
+      description="Une erreur est survenue lors de l'affichage des informations du député."
+      color="red"
+      icon="i-heroicons-exclamation-triangle"
+    />
 
     <div v-else-if="deputy" class="mt-3 flex flex-col gap-4 md:flex-row">
       <div class="w-full md:w-1/3">

--- a/app/pages/assemblee-nationale/groupes/[id]/[name].vue
+++ b/app/pages/assemblee-nationale/groupes/[id]/[name].vue
@@ -37,11 +37,9 @@
         title="Erreur de chargement"
         description="Impossible de charger les informations du groupe parlementaire"
         color="red"
+        class="dark:text-white"
+        icon="i-heroicons-exclamation-triangle"
       >
-        <template #description>
-          {{ error }}
-          <UButton label="Réessayer" color="red" variant="ghost" class="mt-4" @click="refresh()" />
-        </template>
       </UAlert>
     </UContainer>
 

--- a/app/pages/assemblee-nationale/questions/[id].vue
+++ b/app/pages/assemblee-nationale/questions/[id].vue
@@ -42,7 +42,7 @@ const image = computed(() => {
 
 const questionSchema = computed(() => {
   if (!question.value) return null;
-  
+
   return {
     "@context": "https://schema.org",
     "@type": "Question",
@@ -112,7 +112,7 @@ const breadcrumbSchema = computed(() => ({
 
 const webPageSchema = computed(() => {
   if (!question.value) return null;
-  
+
   return {
     "@context": "https://schema.org",
     "@type": "WebPage",
@@ -235,12 +235,13 @@ watchEffect(() => {
       </div>
 
       <!-- Error state -->
-      <div
-        v-else-if="error"
-        class="py-8 text-center text-red-500 dark:text-red-300"
-      >
-        {{ error }}
-      </div>
+      <UAlert v-else-if="error"
+        title="Erreur de chargement"
+        description="Une erreur est survenue lors du chargement de la question"
+        color="red"
+        class="dark:text-white"
+        icon="i-heroicons-exclamation-triangle"
+      />
 
       <!-- Contenu de la question -->
       <div v-else-if="question" class="space-y-6">
@@ -249,7 +250,7 @@ watchEffect(() => {
           <meta itemprop="url" :content="url">
           <meta itemprop="dateCreated" :content="formatDateISO(question.question_date)">
           <meta itemprop="name" :content="question.subject">
-          
+
           <!-- En-tête avec info député -->
           <div
             class="rounded-lg bg-white p-2 shadow-sm dark:bg-gray-800 dark:text-gray-100"
@@ -260,7 +261,7 @@ watchEffect(() => {
               <meta itemprop="familyName" :content="question.deputy.last_name">
               <meta itemprop="jobTitle" content="Député">
               <meta itemprop="image" :content="getImageUrl(question.deputy.photo)">
-              
+
               <div itemprop="worksFor" itemscope itemtype="https://schema.org/GovernmentOrganization">
                 <meta itemprop="name" content="Assemblée nationale du Sénégal">
                 <meta itemprop="url" :content="`${siteUrl}/assemblee-nationale`">
@@ -292,7 +293,7 @@ watchEffect(() => {
                 </div>
               </NuxtLink>
             </div>
-            
+
             <h1 class="mb-4 text-2xl font-bold dark:text-gray-100" itemprop="name">
               {{ question.subject }}
             </h1>
@@ -341,7 +342,7 @@ watchEffect(() => {
             >
               <meta itemprop="contentUrl" :content="getImageUrl(attachment.directus_files_id.id)">
               <meta itemprop="encodingFormat" :content="attachment.directus_files_id.type">
-              
+
               <!-- Image attachments -->
               <img
                 v-if="isImageFile(attachment.directus_files_id.type)"

--- a/app/pages/assemblee-nationale/questions/index.vue
+++ b/app/pages/assemblee-nationale/questions/index.vue
@@ -221,9 +221,13 @@ to="/assemblee-nationale"
         <UIcon name="i-heroicons-arrow-path" class="h-8 w-8 animate-spin" />
       </div>
 
-      <div v-else-if="error" class="py-8 text-center text-red-500 dark:text-red-300">
-        {{ error }}
-      </div>
+      <UAlert
+        v-else-if="error"
+        title="Erreur de chargement"
+        description="Impossible de charger les questions écrites"
+        color="red"
+        icon="i-heroicons-exclamation-triangle"
+      />
 
       <div v-else>
         <div class="mb-2 rounded-lg p-0">

--- a/app/pages/assemblee-nationale/votes/[id].vue
+++ b/app/pages/assemblee-nationale/votes/[id].vue
@@ -38,12 +38,13 @@
       </div>
 
       <!-- Error state -->
-      <div
+      <UAlert
         v-else-if="error"
-        class="py-8 text-center text-red-500 dark:text-red-300"
-      >
-        {{ error }}
-      </div>
+        title="Erreur de chargement"
+        description="Impossible de charger les informations du vote"
+        color="red"
+        icon="i-heroicons-exclamation-triangle"
+      />
 
       <UCard v-else class="mb-8 dark:border-gray-700 dark:bg-gray-800">
         <!-- En-tête -->

--- a/app/pages/conseil-des-ministres/[id]/[slug].vue
+++ b/app/pages/conseil-des-ministres/[id]/[slug].vue
@@ -268,9 +268,13 @@ const formatDateISO = (date: string) => {
       <div class="h-4 w-3/4 animate-pulse rounded bg-gray-200"></div>
     </div>
 
-    <div v-else-if="error" class="py-4 text-center text-red-500">
-      {{ error }}
-    </div>
+    <UAlert
+      v-else-if="error"
+      title="Erreur"
+      description="Une erreur est survenue lors du chargement de l'article."
+      color="red"
+      icon="i-heroicons-exclamation-triangle"
+    />
 
     <template v-else-if="article">
       <article

--- a/app/pages/conseil-des-ministres/index.vue
+++ b/app/pages/conseil-des-ministres/index.vue
@@ -273,9 +273,13 @@ const formatDateISO = (date: string) => {
       />
     </div>
 
-    <div v-else-if="error" class="py-4 text-center text-red-500">
-      {{ error }}
-    </div>
+    <UAlert
+      v-else-if="error"
+      title="Erreur de chargement"
+      description="Impossible de charger les communiqués du Conseil des ministres"
+      color="red"
+      icon="i-heroicons-exclamation-triangle"
+    />
 
     <div v-else-if="articles.length === 0" class="py-12 text-center">
       <UIcon

--- a/app/pages/nomination-senegal/index.vue
+++ b/app/pages/nomination-senegal/index.vue
@@ -309,9 +309,13 @@ watch([filterType, filterGender], () => {
           </template>
 
           <!-- État d'erreur -->
-          <div v-else-if="error" class="py-8 text-center text-red-500">
-            <p>Erreur lors du chargement des nominations</p>
-          </div>
+          <UAlert
+            v-else-if="error"
+            title="Erreur de chargement"
+            description="Impossible de charger les nominations"
+            color="red"
+            icon="i-heroicons-exclamation-triangle"
+          />
 
           <!-- Liste des nominations -->
           <template v-else>


### PR DESCRIPTION
## Contexte
Cette PR fait suite à la volonté d'améliorer l'UX en cachant les détails techniques (routes API, codes d'erreur bruts, stack traces) qui ne sont pas pertinents pour l'utilisateur final.

## Objectif

Améliorer l'expérience utilisateur en remplaçant les messages d'erreur techniques par des messages clairs et compréhensibles.

- Pour la partie don:
> avant

<img width="1003" height="233" alt="image" src="https://github.com/user-attachments/assets/304be65f-d735-4a23-8417-d38e7f4c7581" />

> après

<img width="980" height="223" alt="image" src="https://github.com/user-attachments/assets/e955fe63-4cae-41b8-94aa-45af22947c67" />


- Pour les autres pages (je prends juste l'exemple de actualité)
> avant

<img width="1399" height="200" alt="image" src="https://github.com/user-attachments/assets/8dea4398-70d1-4683-8a7c-b70122a63004" />


> après

<img width="1470" height="252" alt="image" src="https://github.com/user-attachments/assets/e476baa5-3dcd-4c65-be77-43e68d68227c" />

